### PR TITLE
fix: set security to github fallback

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,0 @@
-# Reporting Security Issues
-
-**Please do not report security vulnerabilities through public GitHub issues.**
-
-We at STACKIT take security seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
-
-To report a security issue, please send an email to [stackit-security@stackit.de](mailto:stackit-security@stackit.de).
-
-Our team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.


### PR DESCRIPTION
## Description

Remove security.md to use the fallback file.

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
